### PR TITLE
include original source and destination IPs

### DIFF
--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	goflag "flag"
 	"fmt"
+	"os"
+
 	conf "github.com/sapcc/go-pmtud/internal/config"
 	metr "github.com/sapcc/go-pmtud/internal/metrics"
 	"github.com/sapcc/go-pmtud/internal/nflog"
@@ -12,25 +14,26 @@ import (
 	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
-	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+
 	//"sigs.k8s.io/controller-runtime/pkg/log"
+	"strconv"
+
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"strconv"
 )
 
 var rootCmd = &cobra.Command{
-	Use: "pmtud",
-	Short: "",
-	Long: "",
-	RunE: runRootCmd,
+	Use:     "pmtud",
+	Short:   "",
+	Long:    "",
+	RunE:    runRootCmd,
 	PreRunE: preRunRootCmd,
 }
 var cfg = conf.Config{}
@@ -54,7 +57,7 @@ func init() {
 	cfg.PeerList = make(map[string]conf.PeerEntry)
 }
 
-func preRunRootCmd( cmd *cobra.Command, args []string) error {
+func preRunRootCmd(cmd *cobra.Command, args []string) error {
 	log := zap.New(func(o *zap.Options) {
 		o.Development = true
 	}).WithName("preRunRoot")
@@ -69,13 +72,13 @@ func preRunRootCmd( cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runRootCmd (cmd *cobra.Command, args []string) error {
+func runRootCmd(cmd *cobra.Command, args []string) error {
 	log := zap.New(func(o *zap.Options) {
 		o.Development = true
 	}).WithName("runRoot")
 	ctrl.SetLogger(log)
 	managerOpts := manager.Options{
-		MetricsBindAddress: ":" + strconv.Itoa(viper.GetInt("metrics_port")),
+		MetricsBindAddress:     ":" + strconv.Itoa(viper.GetInt("metrics_port")),
 		HealthProbeBindAddress: ":" + strconv.Itoa(cfg.HealthPort),
 	}
 	restConfig, err := config.GetConfigWithContext(cfg.KubeContext)
@@ -92,9 +95,9 @@ func runRootCmd (cmd *cobra.Command, args []string) error {
 	// add node-controller
 	c, err := controller.New("node-controller", mgr, controller.Options{
 		Reconciler: &node.Reconciler{
-			Log: mgr.GetLogger().WithName("node-controller"),
+			Log:    mgr.GetLogger().WithName("node-controller"),
 			Client: mgr.GetClient(),
-			Cfg: &cfg,
+			Cfg:    &cfg,
 		},
 	})
 	if err != nil {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,41 +1,41 @@
 package metrics
 
 import (
-    "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var SentError = prometheus.NewCounterVec(prometheus.CounterOpts{
-    Name: "go_pmtud_sent_error_peer_total",
-    Help: "Number of errors per peer",
+	Name: "go_pmtud_sent_error_peer_total",
+	Help: "Number of errors per peer",
 }, []string{"node", "peer"})
 
 var Error = prometheus.NewCounterVec(prometheus.CounterOpts{
-    Name: "go_pmtud_error_total",
-    Help: "Number of general errors in go-pmtud",
+	Name: "go_pmtud_error_total",
+	Help: "Number of general errors in go-pmtud",
 }, []string{"node"})
 
 var ArpResolveError = prometheus.NewCounterVec(prometheus.CounterOpts{
-    Name: "go_pmtud_peer_arp_resolve_error",
-    Help: "Number of ARP resolution errors per peer",
+	Name: "go_pmtud_peer_arp_resolve_error",
+	Help: "Number of ARP resolution errors per peer",
 }, []string{"node", "peer"})
 
 var SentPackets = prometheus.NewCounterVec(prometheus.CounterOpts{
-    Name: "go_pmtud_sent_packets_total",
-    Help: "Number of sent ICMP packets",
+	Name: "go_pmtud_sent_packets_total",
+	Help: "Number of sent ICMP packets",
 }, []string{"node"})
 
 var SentPacketsPeer = prometheus.NewCounterVec(prometheus.CounterOpts{
-    Name: "go_pmtud_sent_packets_peer",
-    Help: "Number of sent ICMP packets per peer",
+	Name: "go_pmtud_sent_packets_peer",
+	Help: "Number of sent ICMP packets per peer",
 }, []string{"node", "peer"})
 
 var RecvPackets = prometheus.NewCounterVec(prometheus.CounterOpts{
-    Name: "go_pmtud_recv_packets_total",
-    Help: "Number of received ICMP packets",
-}, []string{"node"})
+	Name: "go_pmtud_recv_packets_total",
+	Help: "Number of received ICMP packets",
+}, []string{"node", "source_ip"})
 
 var CallbackDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-    Name: "go_pmtud_callback_duration_seconds",
-    Buckets: []float64{0.01,0.02,0.03,0.04,0.05,0.06,0.07,0.08,0.09},
-    Help: "Duration of NFlog callback in seconds",
+	Name:    "go_pmtud_callback_duration_seconds",
+	Buckets: []float64{0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09},
+	Help:    "Duration of NFlog callback in seconds",
 }, []string{"node"})

--- a/internal/util/address.go
+++ b/internal/util/address.go
@@ -1,0 +1,21 @@
+package util
+
+import (
+	"net"
+)
+
+// CalcSrcDst counts inner packet IPv4 IPs with bytes due to missing ICMP 3/4 parsing library
+func CalcSrcDst(b []byte) (srcIP net.IP, dstIP net.IP, err error) {
+	src := b[40:44]
+	dst := b[44:48]
+
+	srcIP = src
+	dstIP = dst
+
+	// validate if parsed IPs are valid IPv4 addresses
+	if (net.ParseIP(srcIP.String()) == nil) || (net.ParseIP(dstIP.String()) == nil) {
+		return nil, nil, err
+	} else {
+		return srcIP, dstIP, nil
+	}
+}


### PR DESCRIPTION
* to know for what connection or service IP icmp 3/4 was sent
* some fmt

Old log entry on ICMP receival included only originator of ICMP message:
```
2022-10-24T10:12:41.234405558Z 1.6666063612341962e+09	INFO	runRoot.nfLog-controller	ICMP frag-needed received, resending packet.	{"source": "10.1.2.3"}
```

New message:
```
2022-10-25T07:52:55.934336425Z 1.6666843759338038e+09	INFO	runRoot.nfLog-controller	ICMP frag-needed received, resending packet.	{"ICMP source": "10.1.2.3", "source IP": "10.2.2.2", "could not send to destination IP": "10.3.3.3"}
```